### PR TITLE
Add log_level option for SyslogTailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,18 @@ To make this handle hangs, you'll want to enable a hardware watchdog.
 
 Operating system-level messages from `/dev/log` and `/proc/kmsg`, forwarding
 them to `Logger` with an appropriate level to match the syslog priority parsed
-out of the message.
+out of the message. The level is configurable with the `log_level` option (default is `:error`).
+
+The options are one of: [:emergency, :alert, :critical, :error, :warning, :notice, :informational, :debug]
+
+The `log_level` is treated as the minimum level to be logged. For example, if `:notice` is selected,
+then only levels of `:notice` or above (`:error`, `:alert`, `:critical`) will be logged.
+
+Configure with:
+```
+config :nerves_runtime, :syslog,
+  log_level: :error
+```
 
 ## uevent/udev events
 

--- a/lib/nerves_runtime/application.ex
+++ b/lib/nerves_runtime/application.ex
@@ -25,10 +25,11 @@ defmodule Nerves.Runtime.Application do
 
   defp target_children(_target) do
     kernel_opts = Application.get_env(:nerves_runtime, :kernel, [])
+    syslog_opts = Application.get_env(:nerves_runtime, :syslog, [])
 
     [
       KmsgTailer,
-      SyslogTailer,
+      {SyslogTailer, syslog_opts},
       {Kernel.UEvent, kernel_opts},
       Init
     ]

--- a/lib/nerves_runtime/log/syslog_parser.ex
+++ b/lib/nerves_runtime/log/syslog_parser.ex
@@ -120,6 +120,18 @@ defmodule Nerves.Runtime.Log.SyslogParser do
   defp severity_name(6), do: :informational
   defp severity_name(7), do: :debug
 
+  def severity_code(:emergency), do: 0
+  def severity_code(:alert), do: 1
+  def severity_code(:critical), do: 2
+  def severity_code(:error), do: 3
+  def severity_code(:warning), do: 4
+  def severity_code(:warn), do: severity_code(:warning)
+  def severity_code(:notice), do: 5
+  def severity_code(:informational), do: 6
+  def severity_code(:info), do: severity_code(:informational)
+  def severity_code(:debug), do: 7
+  def severity_code(_), do: severity_code(:error)
+
   @doc """
   Convert severity to an Elixir logger level
   """


### PR DESCRIPTION
Allows the developer to configure the level they want to receive logs at.